### PR TITLE
add func wrap for closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ To publish:
 
     ps.Pub(1)
 
+If the closure captures values, you can use a wrapped function eg:
+
+	// global 
+    var ps = pubsub.New()
+   		func Subscribe(conn net.Conn) {
+    	f := func(i int) { // a closure captures "conn", it will send messages to different network connections
+       		conn.Write([]byte(fmt.Sprint("int subscriber: ", i)))
+    	})
+		ps.Sub(pubsub.NewWrap(f))	// subscribe with a wrapper
+		...
+    }
+	
 Messages are passed to subscriber which have same type argument.
 
 License

--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ To publish:
 
     ps.Pub(1)
 
-If the closure captures values, you can use a wrapped function eg:
+If the closure captures values, you can use a wrapped function, eg:
 
-	// global 
+    // global 
     var ps = pubsub.New()
-   		func Subscribe(conn net.Conn) {
+    // subscribe with a network connection
+    func Subscribe(conn net.Conn) {
     	f := func(i int) { // a closure captures "conn", it will send messages to different network connections
        		conn.Write([]byte(fmt.Sprint("int subscriber: ", i)))
     	})
-		ps.Sub(pubsub.NewWrap(f))	// subscribe with a wrapper
-		...
+        ps.Sub(pubsub.NewWrap(f)) // subscribe with a wrapper
+        ...
     }
 	
 Messages are passed to subscriber which have same type argument.

--- a/pubsub.go
+++ b/pubsub.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"runtime"
 	"sync"
 )
 
@@ -42,10 +41,20 @@ func (pse *PubSubError) Subscriber() interface{} {
 	return pse.f
 }
 
+type wrap struct {
+	f interface{}
+}
+
+func NewFunc(f interface{}) *wrap {
+	w := &wrap{}
+	w.f = f
+	return w
+}
+
 // PubSub contains channel and callbacks.
 type PubSub struct {
 	c chan interface{}
-	f []interface{}
+	w []*wrap
 	m sync.Mutex
 	e chan error
 }
@@ -59,17 +68,17 @@ func New() *PubSub {
 		for v := range ps.c {
 			rv := reflect.ValueOf(v)
 			ps.m.Lock()
-			for _, f := range ps.f {
-				rf := reflect.ValueOf(f)
-				if rv.Type() == reflect.ValueOf(f).Type().In(0) {
+			for _, w := range ps.w {
+				rf := reflect.ValueOf(w.f)
+				if rv.Type() == reflect.ValueOf(w.f).Type().In(0) {
 					go func(f interface{}, rf reflect.Value) {
 						defer func() {
 							if err := recover(); err != nil {
-								ps.e <-&PubSubError{f, err}
+								ps.e <- &PubSubError{f, err}
 							}
 						}()
 						rf.Call([]reflect.Value{rv})
-					}(f, rf)
+					}(w.f, rf)
 				}
 			}
 			ps.m.Unlock()
@@ -83,7 +92,8 @@ func (ps *PubSub) Error() chan error {
 }
 
 // Sub subscribe to the PubSub.
-func (ps *PubSub) Sub(f interface{}) error {
+func (ps *PubSub) Sub(w *wrap) error {
+	f := w.f
 	rf := reflect.ValueOf(f)
 	if rf.Kind() != reflect.Func {
 		return errors.New("Not a function")
@@ -93,31 +103,20 @@ func (ps *PubSub) Sub(f interface{}) error {
 	}
 	ps.m.Lock()
 	defer ps.m.Unlock()
-	ps.f = append(ps.f, f)
+	ps.w = append(ps.w, w)
 	return nil
 }
 
 // Leave unsubscribe to the PubSub.
-func (ps *PubSub) Leave(f interface{}) {
-	var fp uintptr
-	if f == nil {
-		if pc, _, _, ok := runtime.Caller(1); ok {
-			fp = runtime.FuncForPC(pc).Entry()
-		}
-	} else {
-		fp = reflect.ValueOf(f).Pointer()
-	}
+func (ps *PubSub) Leave(w *wrap) {
 	ps.m.Lock()
 	defer ps.m.Unlock()
-	result := make([]interface{}, 0, len(ps.f))
-	last := 0
-	for i, v := range ps.f {
-		if reflect.ValueOf(v).Pointer() == fp {
-			result = append(result, ps.f[last:i]...)
-			last = i + 1
+	for k, v := range ps.w {
+		if w == v {
+			ps.w = append(ps.w[:k], ps.w[k+1:]...)
+			return
 		}
 	}
-	ps.f = append(result, ps.f[last:]...)
 }
 
 // Pub publish to the PubSub.
@@ -128,5 +127,5 @@ func (ps *PubSub) Pub(v interface{}) {
 // Close closes PubSub. To inspect unbsubscribing for another subscruber, you must create message structure to notify them. After publish notifycations, Close should be called.
 func (ps *PubSub) Close() {
 	close(ps.c)
-	ps.f = nil
+	ps.w = nil
 }

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -9,7 +9,7 @@ func TestInt(t *testing.T) {
 	done := make(chan int)
 	ps := pubsub.New()
 	ps.Sub(func(i int) {
-		done <-i
+		done <- i
 	})
 	ps.Pub(1)
 	i := <-done
@@ -22,7 +22,7 @@ func TestString(t *testing.T) {
 	done := make(chan string)
 	ps := pubsub.New()
 	ps.Sub(func(s string) {
-		done <-s
+		done <- s
 	})
 	ps.Pub("hello world")
 	s := <-done
@@ -39,7 +39,7 @@ func TestStruct(t *testing.T) {
 	done := make(chan *F)
 	ps := pubsub.New()
 	ps.Sub(func(f *F) {
-		done <-f
+		done <- f
 	})
 	ps.Pub(&F{"hello world"})
 	f := <-done
@@ -53,10 +53,10 @@ func TestOnly(t *testing.T) {
 	doneF := make(chan *F)
 	ps := pubsub.New()
 	ps.Sub(func(i int) {
-		doneInt <-i
+		doneInt <- i
 	})
 	ps.Sub(func(f *F) {
-		doneF <-f
+		doneF <- f
 	})
 	ps.Pub(&F{"hello world"})
 	ps.Pub(2)


### PR DESCRIPTION
functions, including closures always have the same memory address, I added a wrap for functions, especially for subscribing with closures.

see https://github.com/GameGophers/chat/blob/master/src/chat/service.go for how I use it.