### PR TITLE
Leave() method fix

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -131,7 +131,8 @@ func (ps *PubSub) Leave(f interface{}) {
 	result := make([]*wrap, 0, len(ps.w))
 	last := 0
 	for i, v := range ps.w {
-		if reflect.ValueOf(v).Pointer() == fp {
+		vf := v.f
+		if reflect.ValueOf(vf).Pointer() == fp {
 			result = append(result, ps.w[last:i]...)
 			last = i + 1
 		}


### PR DESCRIPTION
Check the pointer of the function, not the pointer of the wrapper.
Reason why the test didn't fail in the past is because of a race condition. So it should check for that but I didn't know how to.
